### PR TITLE
ignore left- and right- clicks on links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ function routeFromLink(node) {
 
 
 function handleLinkClick(e) {
+	if (e.button !== 0) return;
 	routeFromLink(e.currentTarget || e.target || this);
 	return prevent(e);
 }
@@ -86,6 +87,7 @@ function delegateLinkHandler(e) {
 	let t = e.target;
 	do {
 		if (String(t.nodeName).toUpperCase()==='A' && t.getAttribute('href') && isPreactElement(t)) {
+			if (e.button !== 0) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {
 				return prevent(e);


### PR DESCRIPTION
This allows middle clicks to open the link in a new tab.