### PR TITLE
Support for custom history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import { h, Component } from 'preact';
 import { exec, pathRankSort } from './util';
 
+let customHistory = null;
+
 const ROUTERS = [];
 
 const EMPTY = {};
@@ -13,19 +15,44 @@ function isPreactElement(node) {
 	return ATTR_KEY in node;
 }
 
+function pushUrl(url) {
+	if (customHistory) {
+		customHistory.push(url);
+	} else if (typeof history!=='undefined' && history.pushState) {
+		history.pushState(null, null, url);
+	}
+}
+
+function replaceUrl(url) {
+	if (customHistory) {
+		customHistory.replace(url);
+	} else if (typeof history!=='undefined' && history.pushState) {
+		history.replaceState(null, null, url);
+	}
+}
+
+
+function getCurrentUrl() {
+	let url;
+	if (customHistory) {
+		url = customHistory.getCurrentLocation();
+	} else {
+		url = typeof location!=='undefined' ? location : EMPTY;
+	}
+	return `${url.pathname || ''}${url.search || ''}`;
+}
+
 
 function route(url, replace=false) {
 	if (typeof url!=='string' && url.url) {
 		replace = url.replace;
 		url = url.url;
 	}
-	if (typeof history!=='undefined' && history.pushState) {
-		if (replace===true) {
-			history.replaceState(null, null, url);
-		}
-		else {
-			history.pushState(null, null, url);
-		}
+	if (replace===true) {
+		replaceUrl(url);
+	}
+	else {
+		pushUrl(url);
 	}
 	return routeTo(url);
 }
@@ -39,12 +66,6 @@ function routeTo(url) {
 		}
 	});
 	return didRoute;
-}
-
-
-function getCurrentUrl() {
-	let url = typeof location!=='undefined' ? location : EMPTY;
-	return `${url.pathname || ''}${url.search || ''}`;
 }
 
 
@@ -109,9 +130,16 @@ const Link = ({ children, ...props }) => (
 
 
 class Router extends Component {
-	state = {
-		url: this.props.url || getCurrentUrl()
-	};
+	constructor(props) {
+		super(props);
+		if (props.history) {
+			customHistory = props.history;
+		}
+
+		this.state = {
+			url: this.props.url || getCurrentUrl()
+		};
+	}
 
 	shouldComponentUpdate(props) {
 		if (props.static!==true) return true;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function isPreactElement(node) {
 }
 
 function pushUrl(url) {
-	if (customHistory) {
+	if (customHistory && customHistory.push) {
 		customHistory.push(url);
 	} else if (typeof history!=='undefined' && history.pushState) {
 		history.pushState(null, null, url);
@@ -24,7 +24,7 @@ function pushUrl(url) {
 }
 
 function replaceUrl(url) {
-	if (customHistory) {
+	if (customHistory && customHistory.replace) {
 		customHistory.replace(url);
 	} else if (typeof history!=='undefined' && history.pushState) {
 		history.replaceState(null, null, url);
@@ -34,7 +34,7 @@ function replaceUrl(url) {
 
 function getCurrentUrl() {
 	let url;
-	if (customHistory) {
+	if (customHistory && customHistory.getCurrentLocation) {
 		url = customHistory.getCurrentLocation();
 	} else {
 		url = typeof location!=='undefined' ? location : EMPTY;

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,27 @@ describe('preact-router', () => {
 
 			expect(new Router({})).to.have.deep.property('state.url', location.pathname + (location.search || ''));
 		});
+
+		it('should support custom history', () => {
+			let push = sinon.spy();
+			let replace = sinon.spy();
+			let getCurrentLocation = sinon.spy(() => ({pathname: '/initial'}));
+			let router = new Router({
+				history: { push, replace, getCurrentLocation }
+			});
+
+			router.render({children: [<foo path="/"/>]}, router.state);
+			expect(getCurrentLocation).to.have.been.calledOnce;
+			expect(router).to.have.deep.property('state.url', '/initial');
+
+			route('/foo');
+			expect(push).to.have.been.calledOnce;
+			expect(push).to.have.been.calledWith('/foo');
+
+			route('/bar', true);
+			expect(replace).to.have.been.calledOnce;
+			expect(replace).to.have.been.calledWith('/bar');
+		});
 	});
 
 	describe('route()', () => {


### PR DESCRIPTION
Hi!

Here is a PR to handle custom history. The original idea was to fix https://github.com/developit/preact-router/issues/3 by allowing to use [`history`](https://github.com/ReactTraining/history) (which is internally used by [`react-router`](https://github.com/reactjs/react-router/blob/master/package.json#L35)) to create a history object and pass it to the router. This way, we could use `preact-router` with any custom history manager, like the hash history from the [`history`](https://github.com/ReactTraining/history) package, which would fix https://github.com/developit/preact-router/issues/3 without adding any extra package and not much complexity.

For example (taking the example from the README.md):
```js
import Router from 'preact-router';
import { h } from 'preact';
import { createHashHistory } from 'history';
/** @jsx h */

const Main = () => (
    <Router history={createHashHistory()}>
        <Home path="/" />
        <About path="/about" />
        <Search path="/search/:query" />
    </Router>
);

render(<Main />, document.body);
```

This PR implements this solution, let me know what you think! ☺️