### PR TITLE
Add Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "minified:main": "dist/preact-router.min.js",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "npm-run-all clean transpile minify size",
+    "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",
+    "build": "npm-run-all clean transpile copy-typescript-definition minify size",
     "transpile": "rollup -c rollup.config.js -m ${npm_package_main}.map -f umd -n $npm_package_amdName $npm_package_jsnext_main -o $npm_package_main",
     "minify": "uglifyjs $npm_package_main -cm -o $npm_package_minified_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_minified_main}.map",
     "size": "size=$(gzip-size $npm_package_minified_main) && echo \"gzip size: $size / $(pretty-bytes $size)\"",
@@ -19,6 +20,7 @@
     "prepublish": "npm-run-all build test",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
+  "typings": "./dist/index.d.ts",
   "keywords": [
     "preact",
     "router"
@@ -49,6 +51,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
+    "copyfiles": "^1.0.0",
     "diff": "^3.0.0",
     "eslint": "^3.0.0",
     "eslint-plugin-react": "^6.0.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,30 @@
+export function route(url: string, replace?: boolean): boolean;
+
+export interface RouterProps extends JSX.HTMLAttributes {
+    path: string;
+}
+
+export class Router extends preact.Component<{}, {}> {
+    canRoute(url: string): boolean;
+    getMatchingChildren(children: preact.VNode[], url: string, invoke: boolean): preact.VNode[];
+    routeTo(url: string): boolean;
+    render(props: RouterProps & preact.ComponentProps, {}): preact.VNode;
+}
+
+export interface RouteArgs<PropsType, StateType> {
+    component: preact.Component<PropsType, StateType>;
+    matches: boolean;
+    url: string;
+}
+
+export function Route<PropsType, StateType>({component, url, matches}: RouteArgs<PropsType, StateType>): preact.VNode;
+
+export function Link(props: any): preact.VNode;
+
+export namespace Router {
+    var route: ((url: string, replace?: boolean) => boolean);
+    var Route: (({component, url, matches}) => preact.VNode);
+    var Link: ((props: any) => preact.VNode);
+}
+
+export default Router;


### PR DESCRIPTION
Similar to my PR for preact-mdl. [This JSFiddle](https://jsfiddle.net/developit/weq28uq3/) uses preact-router, so in order to convert that for illustrative purposes, typings had to be made for preact-mdl also. So here they are!