### PR TITLE
Fix for custom histories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,9 +125,18 @@ function delegateLinkHandler(e) {
 }
 
 
-if (typeof addEventListener==='function') {
-	addEventListener('popstate', () => routeTo(getCurrentUrl()));
-	addEventListener('click', delegateLinkHandler);
+let eventListenersInitialized = false;
+
+function initEventListeners() {
+	if (eventListenersInitialized){
+		return;
+	}
+	
+	if (typeof addEventListener==='function') {
+		addEventListener('popstate', () => routeTo(getCurrentUrl()));
+		addEventListener('click', delegateLinkHandler);
+	}
+	eventListenersInitialized = true;
 }
 
 
@@ -146,6 +155,8 @@ class Router extends Component {
 		this.state = {
 			url: this.props.url || getCurrentUrl()
 		};
+		
+		initEventListeners();
 	}
 
 	shouldComponentUpdate(props) {


### PR DESCRIPTION
Currently the EventListeners get added on import, which breaks custom histories which have to add them first.

[`getCurrentUrl`](https://github.com/developit/preact-router/blob/master/src/index.js#L28) would always get the previous url from the custom history

[This](https://github.com/pre-bp/pre-bp/blob/history-4/src/index.js#L17) is the fix we had to apply to get it to work like it should