### PR TITLE
adding module key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/preact-router.js",
   "jsnext:main": "src/index.js",
   "minified:main": "dist/preact-router.min.js",
+  "module": "src/index.js",
   "scripts": {
     "clean": "rimraf dist/",
     "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",


### PR DESCRIPTION
Adding the modules key to `package.json` will expose your ES6 code to `webpack`.
Without this `preact-router` would not be a part of 🌴 Tree shaking.

More details here:
https://github.com/rollup/rollup/wiki/pkg.module