### PR TITLE
Make the Route component forward all URL parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,18 +254,9 @@ class Router extends Component {
 	}
 }
 
-
-const Route = ({ component, url, matches }) => {
-	let attr = {};
-	for (let a in matches) {
-		if (matches.hasOwnProperty(a)) {
-			attr[a] = matches[a];
-		}
-	}
-	attr["url"] = url;
-	return h(component, attr);
+const Route = ({ component, ...props }) => {
+	return h(component, props);
 };
-
 
 Router.route = route;
 Router.Router = Router;

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,14 @@ class Router extends Component {
 
 
 const Route = ({ component, url, matches }) => {
-	return h(component, { url, matches });
+	let attr = {};
+	for (let a in matches) {
+		if (matches.hasOwnProperty(a)) {
+			attr[a] = matches[a];
+		}
+	}
+	attr["url"] = url;
+	return h(component, attr);
 };
 
 


### PR DESCRIPTION
When using `<Router path="/test/:id" component={MyComponent} />` instead
of `<MyComponent path="/test/:id" />` URL parameters (`id`, in this example)
was not "forwarded" to the component's (`MyComponent`, in this example) props. This commit fixes that.

This is useful when, for example, using preact-router from Typescript as using a typescript component directly (instead of wrapping it using the `Route` component) doesn't "compile" as the component's props typically doesn't have a prop named "path".