### PR TITLE
Pass `native` attr to bypass anchor handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ function delegateLinkHandler(e) {
 	let t = e.target;
 	do {
 		if (String(t.nodeName).toUpperCase()==='A' && t.getAttribute('href') && isPreactElement(t)) {
+			if (t.hasAttribute('native')) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {
 				return prevent(e);


### PR DESCRIPTION
~~ via Slack chat

Allows for:

```jsx
<a href="//google.com" native>Google</a>
<a href="//google.com" native={ false }>Caught</a>
```

This won't work with `Link` because it's assumed that use of `<Link />` means that you _know_ you want an internal route link.