### PR TITLE
Fix 'should render a normal link' expectation so that it actually checks the rendered HTML

### DIFF
--- a/test/dom.js
+++ b/test/dom.js
@@ -39,7 +39,7 @@ describe('dom', () => {
 			expect(
 				mount(<Link href="/foo" bar="baz">hello</Link>).outerHTML
 			).to.eql(
-				mount(<a href="/food" bar="baz">hello</a>).outerHTML
+				mount(<a href="/foo" bar="baz">hello</a>).outerHTML
 			);
 		});
 

--- a/test/dom.js
+++ b/test/dom.js
@@ -39,7 +39,7 @@ describe('dom', () => {
 			expect(
 				mount(<Link href="/foo" bar="baz">hello</Link>)
 			).to.eql(
-				mount(<a href="/foo" bar="baz">hello</a>)
+				mount(<a href="/food" bar="baz">hello</a>)
 			);
 		});
 

--- a/test/dom.js
+++ b/test/dom.js
@@ -37,9 +37,9 @@ describe('dom', () => {
 	describe('<Link />', () => {
 		it('should render a normal link', () => {
 			expect(
-				mount(<Link href="/foo" bar="baz">hello</Link>)
+				mount(<Link href="/foo" bar="baz">hello</Link>).outerHTML
 			).to.eql(
-				mount(<a href="/food" bar="baz">hello</a>)
+				mount(<a href="/food" bar="baz">hello</a>).outerHTML
 			);
 		});
 


### PR DESCRIPTION
Since `render` just returns the dom node, the previous equality check would never fail, even when the rendered HTML inside the node was different.

I demonstrated this by changing the expected value (438cf7b0afb00c399c96ead2361a4b363db05f7e) and verifying that the tests still passed ([Build #751](https://travis-ci.org/developit/preact-router/builds/215314475)). After fixing the expectation (09fa51b3e0dbd66e77644496bc43ea97979ea1f9), the tests began failing as expected/desired ([Build #752](https://travis-ci.org/developit/preact-router/builds/215315486)). With the fixed expectation, reverting the intentional test breakage (dd6eb2f688819ee1c70d925246785002e3dd0dab) gets the tests to pass again ([Build #753](https://travis-ci.org/developit/preact-router/builds/215316619)). I've left these individual commits in the PR so that CI can serve as proof of this, but it's fine to squash this into one commit.