### PR TITLE
Rewrite Route component w/o Object rest

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,9 +250,7 @@ class Router extends Component {
 	}
 }
 
-const Route = ({ component, ...props }) => {
-	return h(component, props);
-};
+const Route = props => h(props.component, props);
 
 Router.route = route;
 Router.Router = Router;


### PR DESCRIPTION
Object rest properties aren't supported [in Bublé](https://buble.surge.sh/guide/#object-spread) and require at least one Babel plugin, which affects a project globally. By switching to a simpler `Route` definition (credit @kristoferbaxter), this lib can be compiled without accessory plugins. 

In my projects, I didn't find any issue when `props.component` was passed along. Tests also pass. 

And a nice bonus: this trims 50 bytes from the gzip release 😆 Down to `2207` from `2253`.