### PR TITLE
Lazy Loading readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ import AsyncRoute from 'preact-async-route';
   <Home path="/" />
   <AsyncRoute
     path="/friends"
-    component={ () => import('./friends') }
+    component={ () => import('./friends').then(module => module.default) }
   />
   <AsyncRoute
     path="/friends/:id"
-    component={ () => import('./friend') }
+    component={ () => import('./friend').then(module => module.default) }
     loading={ () => <div>loading...</div> }
   />
 </Router>


### PR DESCRIPTION
Running examples as is I was getting the following error:
"Uncaught DOMException: Failed to execute 'createElement' on 'Document': The tag name provided ('[object Object]') is not a valid name."
Which was not super helpful but fortunatelly the "preact-async-route" repo's README had this bit.