### PR TITLE
Typescript 2.4 compatibility

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,8 +39,12 @@ export class Router extends preact.Component<RouterProps, {}> {
     render(props: RouterProps, {}): preact.VNode;
 }
 
-export interface RouteProps<C> extends RoutableProps {
-    component: preact.AnyComponent<C, any>;
+type AnyComponent<Props> =
+  | preact.FunctionalComponent<Props>
+  | preact.ComponentConstructor<Props, any>;
+
+export interface RouteProps<Props> extends RoutableProps {
+    component: AnyComponent<Props>;
 }
 
 export function Route<C>(


### PR DESCRIPTION
Not sure exactly why this worked before, but it seems 2.4 is slightly more strict about certain definitions