### PR TITLE
Widen Route props type union to Partial<Props>

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,8 +43,8 @@ export interface RouteProps<C> extends RoutableProps {
     component: preact.AnyComponent<C, any>;
 }
 
-export function Route<C>(
-    props: RouteProps<C> & { [P in keyof C]: C[P] }
+export function Route<Props>(
+    props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
 export function Link(props: JSX.HTMLAttributes): preact.VNode;


### PR DESCRIPTION
Works around the issue when props are supplied via URL params, e.g. `path="/:id"`, with strictNullChecks typescript would result in an error as the prop is not passed explicitly