### PR TITLE
Added onChange definition to RouterProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,10 +22,19 @@ export interface RoutableProps {
     default?: boolean;
 }
 
+export interface RouteChangeEvent {
+    router: Router;
+    url: string;
+    previous?: string;
+    active: preact.VNode;
+    current: preact.VNode;
+}
+
 export interface RouterProps extends RoutableProps {
     history?: CustomHistory;
     static?: boolean;
     url?: string;
+    onChange?(e: RouteChangeEvent): void;
 }
 
 export class Router extends preact.Component<RouterProps, {}> {


### PR DESCRIPTION
Found a missing definition when converting a `preact-cli` app created with default options to TypeScript.  Had to guess at which parts of the `RouteChangeEvent` interface were potentially undefined.

Code in the full template that led to this PR: https://github.com/developit/preact-cli/blob/master/examples/full/src/components/app.js#L23

Code that the definition covers: https://github.com/developit/preact-router/blob/master/src/index.js#L238-L244