### PR TITLE
Fix Redirect recipe to avoid infinite back button loop 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ import { route } from 'preact-router';
 
 export default class Redirect extends Component {
   componentWillMount() {
-    route(this.props.to);
+    route(this.props.to, true);
   }
 
   render() {


### PR DESCRIPTION
The `route` call should pass `true` for the `replace` parameter so that `setUrl` will do a `replaceState` rather than a `pushState`. This is important because using `pushState` results in a broken back button. That is, the back button would end up in an infinite loop: if `/foo` redirects to `/bar` using `pushState`, clicking the back button will take you from `/bar` back to `/foo` which will immediately redirect you back to `/bar`! But all is well if you use `replaceState`: `/foo` will instead get replaced in the history stack with `/bar`, which means that clicking the back button will take you back to wherever you were before `/foo` (avoiding the infinite loop).