### PR TITLE
Fix fallback to browser behavior in Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf dist/",
     "copy-typescript-definition": "copyfiles -f src/index.d.ts src/match.d.ts .",
-    "build": "npm-run-all --silent clean transpile transpile:match copy-typescript-definition size",
+    "build": "npm-run-all clean transpile transpile:match copy-typescript-definition size",
     "transpile": "rollup -c --environment FORMAT:umd && rollup -c --environment FORMAT:es",
     "transpile:match": "babel src/match.js -o match.js -f umd",
     "size": "size=$(gzip-size $npm_package_main) && echo \"gzip size: $size / $(pretty-bytes $size)\"",
@@ -17,7 +17,7 @@
     "lint": "eslint {src,test,test_helpers}",
     "test:karma": "karma start --single-run",
     "test:watch": "karma start",
-    "prepublish": "npm-run-all build test",
+    "prepublish": "npm-run-all build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,11 @@ function initEventListeners() {
 	eventListenersInitialized = true;
 }
 
+// hack! Not sure how to make this fix work: https://github.com/developit/preact-router/pull/232
+// so in the mean time Chris is using this to fix his production memory leak
+function clearGlobalState() {
+	ROUTERS.splice(0, ROUTERS.length);
+}
 
 class Router extends Component {
 	constructor(props) {
@@ -266,5 +271,5 @@ Router.Router = Router;
 Router.Route = Route;
 Router.Link = Link;
 
-export { subscribers, getCurrentUrl, route, Router, Route, Link };
+export { subscribers, getCurrentUrl, route, Router, Route, Link, clearGlobalState };
 export default Router;

--- a/src/index.js
+++ b/src/index.js
@@ -189,11 +189,11 @@ class Router extends Component {
 	}
 
 	componentWillMount() {
+		ROUTERS.push(this);
 		this.updating = true;
 	}
 
 	componentDidMount() {
-		ROUTERS.push(this);
 		if (customHistory) {
 			this.unlisten = customHistory.listen((location) => {
 				this.routeTo(`${location.pathname || ''}${location.search || ''}`);

--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,10 @@ function routeFromLink(node) {
 
 function handleLinkClick(e) {
 	if (e.button==0) {
-		routeFromLink(e.currentTarget || e.target || this);
-		return prevent(e);
+		if (routeFromLink(e.currentTarget || e.target || this)) {
+			return prevent(e);
+		}
+		return true;
 	}
 }
 


### PR DESCRIPTION
Problem: if you click a `<Link>`, and none of the exiting routers handle it, it currently does nothing.

I think this is the intended behavior. If no exiting router handles it, then we *don't* preventDefault, and let the normal browser link handling work.