### PR TITLE
Use new attribute interfaces in TypeScript types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,8 +65,8 @@ export function Route<Props>(
 export function Link(props: {activeClassName?: string} & JSX.HTMLAttributes): preact.VNode;
 
 declare module 'preact' {
-    export interface ComponentProps<C extends preact.Component<any, any> | preact.FunctionalComponent<any>> extends RoutableProps {}
-    export interface PreactHTMLAttributes extends RoutableProps {}
+    export interface Attributes extends RoutableProps {}
+    export interface ClassAttributes<T> extends RoutableProps {}
 }
 
 export default Router;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,7 +66,6 @@ export function Link(props: {activeClassName?: string} & JSX.HTMLAttributes): pr
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}
-    export interface ClassAttributes<T> extends RoutableProps {}
 }
 
 export default Router;


### PR DESCRIPTION
The next release of Preact will include changes to the TypeScript types that deprecate the `ComponentProps` and `PreactHTMLAttributes` interfaces. This PR updates the preact-router types to use the new interfaces.

This PR should not be merged until after the updated Preact types are released (likely will happen in Preact 8.2.8)