### PR TITLE
Replace HTTP links with HTTPS in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # preact-router
 
-[![NPM](http://img.shields.io/npm/v/preact-router.svg)](https://www.npmjs.com/package/preact-router)
+[![NPM](https://img.shields.io/npm/v/preact-router.svg)](https://www.npmjs.com/package/preact-router)
 [![travis-ci](https://travis-ci.org/developit/preact-router.svg)](https://travis-ci.org/developit/preact-router)
 
 Connect your [Preact] components up to that address bar.
@@ -9,9 +9,9 @@ Connect your [Preact] components up to that address bar.
 
 > 💁 **Note:** This is not a preact-compatible version of React Router. `preact-router` is a simple URL wiring and does no orchestration for you.
 >
-> If you're looking for more complex solutions like nested routes and view composition, [react-router](https://github.com/ReactTraining/react-router) works great with preact as long as you alias in [preact-compat](https://github.com/developit/preact-compat).  React Router 4 even [works directly with Preact](http://codepen.io/developit/pen/BWxepY?editors=0010), no compatibility layer needed!
+> If you're looking for more complex solutions like nested routes and view composition, [react-router](https://github.com/ReactTraining/react-router) works great with preact as long as you alias in [preact-compat](https://github.com/developit/preact-compat).  React Router 4 even [works directly with Preact](https://codepen.io/developit/pen/BWxepY?editors=0010), no compatibility layer needed!
 
-#### [See a Real-world Example :arrow_right:](http://jsfiddle.net/developit/qc73v9va/)
+#### [See a Real-world Example :arrow_right:](https://jsfiddle.net/developit/qc73v9va/)
 
 
 ---
@@ -251,4 +251,4 @@ route('/page-3', true)  // replaces the current history entry
 
 
 [Preact]: https://github.com/developit/preact
-[MIT]: http://choosealicense.com/licenses/mit/
+[MIT]: https://choosealicense.com/licenses/mit/


### PR DESCRIPTION
Tried these links and they seem to be available or redirect to HTTPS anyways.