### PR TITLE
Extracted match check to allow custom match checker when extending class

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -12,6 +12,9 @@ export class Match extends Component {
 	componentWillUnmount() {
 		subscribers.splice(subscribers.indexOf(this.update)>>>0, 1);
 	}
+	isMatch(path) {
+		return path===this.props.path;
+	}
 	render(props) {
 		let url = this.nextUrl || getCurrentUrl(),
 			path = url.replace(/\?.+$/,'');
@@ -19,7 +22,7 @@ export class Match extends Component {
 		return props.children[0] && props.children[0]({
 			url,
 			path,
-			matches: path===props.path
+			matches: this.isMatch(path)
 		});
 	}
 }


### PR DESCRIPTION
This match is only for exact matches of the path, I wanted to extend this for a project but since is inside the render function was not possible to do it without rewriting that function. This way we can extend that condition without changing the render one.