### PR TITLE
[feature] - add support for trailing slashes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,7 @@ export interface CustomHistory {
 export interface RoutableProps {
     path?: string;
     default?: boolean;
+    trailing?: boolean;
 }
 
 export interface RouterOnChangeArgs {

--- a/src/util.js
+++ b/src/util.js
@@ -38,6 +38,7 @@ export function exec(url, route, opts) {
 			matches[param] = decodeURIComponent(val);
 			if (plus || star) {
 				matches[param] = url.slice(i).map(decodeURIComponent).join('/');
+				if (opts.trailing) { matches[param] += '/' }
 				break;
 			}
 		}

--- a/test/router.tsx
+++ b/test/router.tsx
@@ -20,6 +20,7 @@ function RouterWithComponents() {
             <div path="/a"></div>
             <ClassComponent path="/b" />
             <SomeFunctionalComponent path="/c" />
+            <SomeFunctionalComponent path="/d" trailing/>
         </Router>
     )
 }
@@ -31,6 +32,7 @@ function RouterWithRoutes() {
             <Route default component={SomeFunctionalComponent} />
             <Route path="/a" component={ClassComponent} />
             <Route path="/b" component={SomeFunctionalComponent} />
+            <Route path="/c/" component={ClassComponent} trailing/>
         </Router>
     );
 }

--- a/test/util.js
+++ b/test/util.js
@@ -106,5 +106,12 @@ describe('util', () => {
 			expect(exec('/a/b', '/:foo+', {})).to.eql({ foo:'a/b' });
 			expect(exec('/a/b/c', '/:foo+', {})).to.eql({ foo:'a/b/c' });
 		});
+
+		it('should include trailing slash when trailing is selected', () => {
+			expect(exec('/', '/:foo+', { trailing: true })).to.eql(false);
+			expect(exec('/a', '/:foo+', { trailing: true })).to.eql({ foo:'a/' });
+			expect(exec('/a/b', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/' });
+			expect(exec('/a/b/c', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/c/' });
+		});
 	});
 });

--- a/test/util.js
+++ b/test/util.js
@@ -112,6 +112,11 @@ describe('util', () => {
 			expect(exec('/a', '/:foo+', { trailing: true })).to.eql({ foo:'a/' });
 			expect(exec('/a/b', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/' });
 			expect(exec('/a/b/c', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/c/' });
+
+			expect(exec('/', '/:foo+', { trailing: false })).to.eql(false);
+			expect(exec('/a', '/:foo+', { trailing: false })).to.eql({ foo:'a' });
+			expect(exec('/a/b', '/:foo+', { trailing: false })).to.eql({ foo:'a/b' });
+			expect(exec('/a/b/c', '/:foo+', { trailing: false })).to.eql({ foo:'a/b/c' });
 		});
 	});
 });

--- a/test/util.js
+++ b/test/util.js
@@ -112,7 +112,7 @@ describe('util', () => {
 			expect(exec('/a', '/:foo+', { trailing: true })).to.eql({ foo:'a/' });
 			expect(exec('/a/b', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/' });
 			expect(exec('/a/b/c', '/:foo+', { trailing: true })).to.eql({ foo:'a/b/c/' });
-
+			// The below tests are for backwards compatibility
 			expect(exec('/', '/:foo+', { trailing: false })).to.eql(false);
 			expect(exec('/a', '/:foo+', { trailing: false })).to.eql({ foo:'a' });
 			expect(exec('/a/b', '/:foo+', { trailing: false })).to.eql({ foo:'a/b' });


### PR DESCRIPTION
**Why?**
In some hosting configurations, the trailing slash is important. Currently all trailing slashes are stripped.

**Is this a breaking change?**
No. This is opt-in only.

**Are there tests?**
Yes.