### PR TITLE
Fix access to JSX types with preact@next

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,7 @@ export function Route<Props>(
     props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
-export function Link(props: {activeClassName?: string} & JSX.HTMLAttributes): preact.VNode;
+export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}


### PR DESCRIPTION
With Preact X the JSX namespace isn't global anymore, and needs to be accessed from the `preact` export. This PR addresses this issue.