### PR TITLE
Fix preact JSX namespacing, and Children

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ render(
 `<Link>` is just a normal link, but it automatically adds and removes an "active" classname to itself based on whether it matches the current URL.
 
 ```js
-import { Router } from 'preact-router';
-import { Link } from 'preact-router/match';
+import { Router, Link } from 'preact-router';
 
 render(
   <div>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/developit/preact-router",
   "peerDependencies": {
-    "preact": ">=10 || ^10.0.0-alpha.0"
+    "preact": ">=10 || ^10.0.0-beta.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -86,7 +86,7 @@
     "rollup-plugin-uglify": "^1.0.1",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
-    "typescript": "^2.5.3",
+    "typescript": "^3.4.4",
     "webpack": "^1.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mocha": "^3.0.0",
     "npm-run-all": "^3.0.0",
     "phantomjs-prebuilt": "^2.1.7",
-    "preact": "^10.0.0-alpha.0",
+    "preact": "^10.0.0-beta.0",
     "pretty-bytes-cli": "^1.0.0",
     "rimraf": "^2.5.1",
     "rollup": "^0.41.6",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,7 @@ export function Route<Props>(
     props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
-export function Link(props: {activeClassName?: string} & JSX.HTMLAttributes): preact.VNode;
+export function Link(props: {activeClassName?: string} & preact.JSX.HTMLAttributes): preact.VNode;
 
 declare module 'preact' {
     export interface Attributes extends RoutableProps {}

--- a/src/match.d.ts
+++ b/src/match.d.ts
@@ -6,7 +6,7 @@ export class Match extends preact.Component<RoutableProps, {}> {
     render(): preact.VNode;
 }
 
-export interface LinkProps extends JSX.HTMLAttributes {
+export interface LinkProps extends preact.JSX.HTMLAttributes {
     activeClassName: string;
 }
 

--- a/src/match.d.ts
+++ b/src/match.d.ts
@@ -8,6 +8,7 @@ export class Match extends preact.Component<RoutableProps, {}> {
 
 export interface LinkProps extends preact.JSX.HTMLAttributes {
     activeClassName: string;
+    children?: preact.ComponentChildren;
 }
 
 export function Link(props: LinkProps): preact.VNode;


### PR DESCRIPTION
Fixed the move in preactX to using `preact.JSX`. I also added in an `Children` prop into LinkProps, as it doesn't exist in the default JSX namespace.