### PR TITLE
Don't try to intercept links inside contenteditable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ function delegateLinkHandler(e) {
 
 	let t = e.target;
 	do {
-		if (t.localName === 'a' && t.getAttribute('href')) {
+		if (t.localName === 'a' && t.getAttribute('href') && !t.isContentEditable) {
 			if (t.hasAttribute('data-native') || t.hasAttribute('native')) return;
 			// if link is handled by the router, prevent browser defaults
 			if (routeFromLink(t)) {

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -118,6 +118,25 @@ describe('dom', () => {
 			expect(onChange).not.toHaveBeenCalled();
 			expect(location.href).toContain('#foo');
 		});
+
+		it('should not intercept links inside contenteditable', () => {
+			let onChange = jasmine.createSpy();
+			mount(
+				<div>
+					<div contenteditable>
+						<a href="#foo">foo</a>
+					</div>
+					<Router onChange={onChange}>
+						<div default />
+					</Router>
+				</div>
+			);
+			onChange.calls.reset();
+			act(() => {
+				$('a').click();
+			});
+			expect(onChange).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('Router', () => {


### PR DESCRIPTION
Links inside contenteditable don't seem to do anything, which makes sense in an editing context, but the global handler from preact-router makes them active again. This change avoids that by ignoring contenteditable links.