### PR TITLE
Fix the types for Link following recent preact type changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,11 @@ import * as preact from 'preact';
 export function route(url: string, replace?: boolean): boolean;
 export function route(options: { url: string; replace?: boolean }): boolean;
 
-export function exec(url: string, route: string, opts: { default?: boolean }): false | Record<string, string | undefined>;
+export function exec(
+	url: string,
+	route: string,
+	opts: { default?: boolean }
+): false | Record<string, string | undefined>;
 
 export function getCurrentUrl(): string;
 
@@ -69,9 +73,7 @@ export function Route<Props>(
 	props: RouteProps<Props> & Partial<Props>
 ): preact.VNode;
 
-export function Link(
-	props: preact.JSX.HTMLAttributes<HTMLAnchorElement>
-): preact.VNode;
+export function Link(props: preact.JSX.IntrinsicElements['a']): preact.VNode;
 
 export function useRouter<
 	RouteParams extends Record<string, string | undefined> | null = Record<

--- a/match/index.d.ts
+++ b/match/index.d.ts
@@ -6,7 +6,11 @@ export class Match extends preact.Component<RoutableProps, {}> {
 	render(): preact.VNode;
 }
 
-export interface LinkProps extends preact.JSX.HTMLAttributes<HTMLAnchorElement> {
+// Typescript doesn't allow to extends directly from an expression (see
+// https://github.com/microsoft/TypeScript/issues/31843). Assigning to a
+// separate type first makes it work.
+type AnchorElement = preact.JSX.IntrinsicElements['a'];
+export interface LinkProps extends AnchorElement {
 	activeClassName?: string;
 	children?: preact.ComponentChildren;
 }


### PR DESCRIPTION
In Preact 10.25 the types were made stricter (see https://github.com/preactjs/preact/pull/4546/files). As a result, `href` was removed from `HTMLAttributes` and links now use `HTMLAnchorAttributes`.

By using `preact.JSX.IntrinsicElements['a']` we support both versions of preact.